### PR TITLE
Remove undeclared dependency on lodash

### DIFF
--- a/src/app/scenario/step.component.ts
+++ b/src/app/scenario/step.component.ts
@@ -25,9 +25,10 @@ import { VMInfoConfig } from '../VMInfoConfig';
 import { environment } from 'src/environments/environment';
 import { ShellService } from '../services/shell.service';
 import { atou } from '../unicode';
-import { escape } from 'lodash';
 import { SplitAreaDirective, SplitComponent } from "angular-split";
 
+// Replacement for lodash's escape
+const escape = (s: string) => s.replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`);
 
 @Component({
     templateUrl: 'step.component.html',


### PR DESCRIPTION
This replaces usage of `_.escape` with our own implementation.

This has the following advantages:

- no (undeclared) dependency on lodash
- 500kB smaller vendor bundle
- no warnings about optimization bailout during builds or in browser console

This is a preview/RFC before submitting a PR upstream.